### PR TITLE
feat: add todos CRUD with TypeORM and validation

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,13 @@
+module.exports = {
+  type: 'mssql',
+  host: 'localhost',
+  port: 1433,
+  username: 'sa',
+  password: 'your_password',
+  database: 'todos_db',
+  synchronize: true,
+  entities: ['dist/**/*.entity{.ts,.js}'],
+  options: {
+    encrypt: false,
+  },
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,26 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TodosModule } from './todos/todos.module';
 
 @Module({
-  imports: [],
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'mssql',
+      host: 'localhost',
+      port: 1433,
+      username: 'sa',
+      password: 'your_password',
+      database: 'todos_db',
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      synchronize: true,
+      options: {
+        encrypt: false,
+      },
+    }),
+    TodosModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/todos/dto/create-todo.dto.ts
+++ b/src/todos/dto/create-todo.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
+
+export class CreateTodoDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isCompleted?: boolean;
+}

--- a/src/todos/dto/update-todo.dto.ts
+++ b/src/todos/dto/update-todo.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
+
+export class UpdateTodoDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isCompleted?: boolean;
+}

--- a/src/todos/todo.entity.ts
+++ b/src/todos/todo.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Todo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ default: false })
+  isCompleted: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/todos/todos.controller.ts
+++ b/src/todos/todos.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+} from '@nestjs/common';
+import { TodosService } from './todos.service';
+import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
+import { Todo } from './todo.entity';
+
+@Controller('todos')
+export class TodosController {
+  constructor(private readonly todosService: TodosService) {}
+
+  @Get()
+  findAll(): Promise<Todo[]> {
+    return this.todosService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Todo> {
+    return this.todosService.findOne(+id);
+  }
+
+  @Post()
+  create(@Body() createTodoDto: CreateTodoDto): Promise<Todo> {
+    return this.todosService.create(createTodoDto);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateTodoDto: UpdateTodoDto,
+  ): Promise<Todo> {
+    return this.todosService.update(+id, updateTodoDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.todosService.remove(+id);
+  }
+}

--- a/src/todos/todos.module.ts
+++ b/src/todos/todos.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Todo } from './todo.entity';
+import { TodosService } from './todos.service';
+import { TodosController } from './todos.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Todo])],
+  providers: [TodosService],
+  controllers: [TodosController],
+})
+export class TodosModule {}

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Todo } from './todo.entity';
+import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
+
+@Injectable()
+export class TodosService {
+  constructor(
+    @InjectRepository(Todo) private todosRepository: Repository<Todo>,
+  ) {}
+
+  findAll(): Promise<Todo[]> {
+    return this.todosRepository.find();
+  }
+
+  async findOne(id: number): Promise<Todo> {
+    const todo = await this.todosRepository.findOne({ where: { id } });
+    if (!todo) {
+      throw new NotFoundException(`Todo #${id} not found`);
+    }
+    return todo;
+  }
+
+  create(createTodoDto: CreateTodoDto): Promise<Todo> {
+    const todo = this.todosRepository.create(createTodoDto);
+    return this.todosRepository.save(todo);
+  }
+
+  async update(id: number, updateTodoDto: UpdateTodoDto): Promise<Todo> {
+    const todo = await this.findOne(id);
+    Object.assign(todo, updateTodoDto);
+    return this.todosRepository.save(todo);
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.todosRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Todo #${id} not found`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure TypeORM connection to SQL Server and register TodosModule
- add Todo entity, DTOs, service, and controller for full CRUD API
- enable global validation pipe and add ormconfig

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unsafe call of a(n) `error` type typed value)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d715f6c83318f68e77366627e48