### PR TITLE
feat: add todos CRUD with TypeORM, validation, API key auth, and docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+dist
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN npm install -g pnpm && pnpm install
+COPY . .
+RUN pnpm build
+
+# Production stage
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN npm install -g pnpm && pnpm install --prod
+COPY --from=builder /app/dist ./dist
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment:
+      SA_PASSWORD: your_password
+      ACCEPT_EULA: "Y"
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql-data:/var/opt/mssql
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      DB_HOST: db
+      DB_PORT: 1433
+      DB_USERNAME: sa
+      DB_PASSWORD: your_password
+      DB_NAME: todos_db
+      API_KEY: my-secret-key
+    depends_on:
+      - db
+volumes:
+  mssql-data:

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,13 @@
+module.exports = {
+  type: 'mssql',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '1433', 10),
+  username: process.env.DB_USERNAME || 'sa',
+  password: process.env.DB_PASSWORD || 'your_password',
+  database: process.env.DB_NAME || 'todos_db',
+  synchronize: true,
+  entities: ['dist/**/*.entity{.ts,.js}'],
+  options: {
+    encrypt: false,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/typeorm": "^11.0.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.20",
+    "mssql": "^9.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,29 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ApiKeyGuard } from './auth/api-key.guard';
+import { TodosModule } from './todos/todos.module';
 
 @Module({
-  imports: [],
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'mssql',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT ?? '1433', 10),
+      username: process.env.DB_USERNAME || 'sa',
+      password: process.env.DB_PASSWORD || 'your_password',
+      database: process.env.DB_NAME || 'todos_db',
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      synchronize: true,
+      options: {
+        encrypt: false,
+      },
+    }),
+    TodosModule,
+  ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, { provide: APP_GUARD, useClass: ApiKeyGuard }],
 })
 export class AppModule {}

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -1,0 +1,21 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  private readonly apiKey = process.env.API_KEY || 'my-secret-key';
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const headerKey = request.headers['x-api-key'];
+
+    if (headerKey !== this.apiKey) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+    return true;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/todos/dto/create-todo.dto.ts
+++ b/src/todos/dto/create-todo.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
+
+export class CreateTodoDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isCompleted?: boolean;
+}

--- a/src/todos/dto/update-todo.dto.ts
+++ b/src/todos/dto/update-todo.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
+
+export class UpdateTodoDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isCompleted?: boolean;
+}

--- a/src/todos/todo.entity.ts
+++ b/src/todos/todo.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Todo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ default: false })
+  isCompleted: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/todos/todos.controller.ts
+++ b/src/todos/todos.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+} from '@nestjs/common';
+import { TodosService } from './todos.service';
+import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
+import { Todo } from './todo.entity';
+
+@Controller('todos')
+export class TodosController {
+  constructor(private readonly todosService: TodosService) {}
+
+  @Get()
+  findAll(): Promise<Todo[]> {
+    return this.todosService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Todo> {
+    return this.todosService.findOne(+id);
+  }
+
+  @Post()
+  create(@Body() createTodoDto: CreateTodoDto): Promise<Todo> {
+    return this.todosService.create(createTodoDto);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateTodoDto: UpdateTodoDto,
+  ): Promise<Todo> {
+    return this.todosService.update(+id, updateTodoDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.todosService.remove(+id);
+  }
+}

--- a/src/todos/todos.module.ts
+++ b/src/todos/todos.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Todo } from './todo.entity';
+import { TodosService } from './todos.service';
+import { TodosController } from './todos.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Todo])],
+  providers: [TodosService],
+  controllers: [TodosController],
+})
+export class TodosModule {}

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Todo } from './todo.entity';
+import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
+
+@Injectable()
+export class TodosService {
+  constructor(
+    @InjectRepository(Todo) private todosRepository: Repository<Todo>,
+  ) {}
+
+  findAll(): Promise<Todo[]> {
+    return this.todosRepository.find();
+  }
+
+  async findOne(id: number): Promise<Todo> {
+    const todo = await this.todosRepository.findOne({ where: { id } });
+    if (!todo) {
+      throw new NotFoundException(`Todo #${id} not found`);
+    }
+    return todo;
+  }
+
+  create(createTodoDto: CreateTodoDto): Promise<Todo> {
+    const todo = this.todosRepository.create(createTodoDto);
+    return this.todosRepository.save(todo);
+  }
+
+  async update(id: number, updateTodoDto: UpdateTodoDto): Promise<Todo> {
+    const todo = await this.findOne(id);
+    Object.assign(todo, updateTodoDto);
+    return this.todosRepository.save(todo);
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.todosRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Todo #${id} not found`);
+    }
+  }
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -19,6 +19,7 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')
+      .set('x-api-key', 'my-secret-key')
       .expect(200)
       .expect('Hello World!');
   });


### PR DESCRIPTION
## Summary
- configure TypeORM connection to SQL Server and register TodosModule
- add Todo entity, DTOs, service, controller for CRUD
- enable global validation pipe and add ormconfig
- secure all routes with API key guard
- add Dockerfile and docker-compose for SQL Server deployment

## Testing
- `pnpm test`
- `pnpm test:e2e` *(fails: Cannot find module '@nestjs/typeorm')*
- `pnpm lint` *(fails: Unsafe member access .save on an `error` typed value)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d715f6c83318f68e77366627e48