### PR TITLE
Add database migration task

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ $ pnpm run test:e2e
 $ pnpm run test:cov
 ```
 
+## Database migrations
+
+Run pending database migrations before starting the application in a deployment environment:
+
+```bash
+$ pnpm run migration:run
+```
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:run": "typeorm-ts-node-commonjs -d src/data-source.ts migration:run"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,7 +16,9 @@ import { TodosModule } from './todos/todos.module';
       password: process.env.DB_PASSWORD || 'YourStrong@Passw0rd',
       database: process.env.DB_NAME || 'todos_db',
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
-      synchronize: true,
+      migrations: [__dirname + '/migrations/*{.ts,.js}'],
+      migrationsRun: true,
+      synchronize: false,
       options: {
         encrypt: false,
       },

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,13 +1,16 @@
-module.exports = {
+import { DataSource } from 'typeorm';
+
+export default new DataSource({
   type: 'mssql',
   host: process.env.DB_HOST || 'localhost',
   port: parseInt(process.env.DB_PORT || '1433', 10),
   username: process.env.DB_USERNAME || 'sa',
   password: process.env.DB_PASSWORD || 'YourStrong@Passw0rd',
   database: process.env.DB_NAME || 'todos_db',
-  synchronize: true,
-  entities: ['dist/**/*.entity{.ts,.js}'],
+  entities: ['src/**/*.entity{.ts,.js}'],
+  migrations: ['src/migrations/*{.ts,.js}'],
+  synchronize: false,
   options: {
     encrypt: false,
   },
-};
+});

--- a/src/migrations/1710000000000-CreateTodosTable.ts
+++ b/src/migrations/1710000000000-CreateTodosTable.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTodosTable1710000000000 implements MigrationInterface {
+  name = 'CreateTodosTable1710000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'todo',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'title',
+            type: 'nvarchar',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'nvarchar',
+            isNullable: true,
+          },
+          {
+            name: 'isCompleted',
+            type: 'bit',
+            default: 0,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            default: 'GETDATE()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            default: 'GETDATE()',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('todo');
+  }
+}


### PR DESCRIPTION
## Summary
- configure TypeORM migrations and run them on startup
- provide initial migration for todos table
- add `migration:run` npm script and document usage

## Testing
- `pnpm lint` *(fails: Unsafe call and member access errors)*
- `pnpm test` *(fails: Cannot find module '@nestjs/testing')*
- `pnpm test:e2e` *(fails: Cannot find module '@nestjs/testing')*
- `pnpm migration:run` *(fails: typeorm-ts-node-commonjs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b126a06e488331a447cf556df01417