### PR TITLE
feat: add qclab api

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ApiKeyGuard } from './auth/api-key.guard';
 import { TodosModule } from './todos/todos.module';
+import { QclabModule } from './qclab/qclab.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { TodosModule } from './todos/todos.module';
       },
     }),
     TodosModule,
+    QclabModule,
   ],
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: ApiKeyGuard }],

--- a/src/migrations/1756442000000-CreateQclabTables.ts
+++ b/src/migrations/1756442000000-CreateQclabTables.ts
@@ -1,0 +1,97 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateQclabTables1756442000000 implements MigrationInterface {
+  name = 'CreateQclabTables1756442000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'qclab',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'CompanyCode', type: 'nvarchar', isNullable: false },
+          { name: 'BranchCode', type: 'nvarchar', isNullable: false },
+          { name: 'UnitCode', type: 'nvarchar', isNullable: false },
+          { name: 'DataSource', type: 'nvarchar', isNullable: false },
+          { name: 'AnalysisType', type: 'nvarchar', isNullable: false },
+          { name: 'Time', type: 'nvarchar', isNullable: false },
+          { name: 'Day', type: 'nvarchar', isNullable: false },
+          { name: 'Month', type: 'nvarchar', isNullable: false },
+          { name: 'Year', type: 'nvarchar', isNullable: false },
+          { name: 'AnalyticalMethod', type: 'nvarchar', isNullable: false },
+          { name: 'AnalyticalTask', type: 'nvarchar', isNullable: false },
+          { name: 'Grade', type: 'nvarchar', isNullable: false },
+          { name: 'TypeStandard', type: 'nvarchar', isNullable: false },
+          { name: 'RunsDone', type: 'nvarchar', isNullable: false },
+          { name: 'RunsInAverage', type: 'nvarchar', isNullable: false },
+          { name: 'RunNumber', type: 'nvarchar', isNullable: false },
+          { name: 'RunType', type: 'nvarchar', isNullable: false },
+          { name: 'SID1', type: 'nvarchar', isNullable: false },
+          { name: 'SID2', type: 'nvarchar', isNullable: false },
+          { name: 'SID3', type: 'nvarchar', isNullable: false },
+          { name: 'SID4', type: 'nvarchar', isNullable: false },
+          { name: 'SID5', type: 'nvarchar', isNullable: false },
+          { name: 'SID6', type: 'nvarchar', isNullable: false },
+          { name: 'SID7', type: 'nvarchar', isNullable: false },
+          { name: 'SID8', type: 'nvarchar', isNullable: false },
+          { name: 'SID9', type: 'nvarchar', isNullable: false },
+          { name: 'SID10', type: 'nvarchar', isNullable: false },
+          { name: 'NumberOfElement', type: 'nvarchar', isNullable: false },
+          { name: 'createdAt', type: 'datetime', default: 'GETDATE()' },
+          { name: 'updatedAt', type: 'datetime', default: 'GETDATE()' },
+        ],
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'qclab_element',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'qclabId', type: 'int', isNullable: false },
+          { name: 'ElementName', type: 'nvarchar', isNullable: false },
+          { name: 'ElementFlag', type: 'nvarchar', isNullable: false },
+          { name: 'LowerGrade', type: 'nvarchar', isNullable: false },
+          { name: 'UpperGrade', type: 'nvarchar', isNullable: false },
+          { name: 'InternalLowerGrade', type: 'nvarchar', isNullable: false },
+          { name: 'InternalUpperGrade', type: 'nvarchar', isNullable: false },
+          { name: 'ElementValue', type: 'nvarchar', isNullable: false },
+          { name: 'createdAt', type: 'datetime', default: 'GETDATE()' },
+          { name: 'updatedAt', type: 'datetime', default: 'GETDATE()' },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'qclab_element',
+      new TableForeignKey({
+        columnNames: ['qclabId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'qclab',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('qclab_element');
+    await queryRunner.dropTable('qclab');
+  }
+}

--- a/src/qclab/dto/create-qclab.dto.ts
+++ b/src/qclab/dto/create-qclab.dto.ts
@@ -1,0 +1,122 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsString, ValidateNested } from 'class-validator';
+
+export class HeaderDataDto {
+  @IsString()
+  CompanyCode: string;
+
+  @IsString()
+  BranchCode: string;
+
+  @IsString()
+  UnitCode: string;
+
+  @IsString()
+  DataSource: string;
+
+  @IsString()
+  AnalysisType: string;
+
+  @IsString()
+  Time: string;
+
+  @IsString()
+  Day: string;
+
+  @IsString()
+  Month: string;
+
+  @IsString()
+  Year: string;
+
+  @IsString()
+  AnalyticalMethod: string;
+
+  @IsString()
+  AnalyticalTask: string;
+
+  @IsString()
+  Grade: string;
+
+  @IsString()
+  TypeStandard: string;
+
+  @IsString()
+  RunsDone: string;
+
+  @IsString()
+  RunsInAverage: string;
+
+  @IsString()
+  RunNumber: string;
+
+  @IsString()
+  RunType: string;
+
+  @IsString()
+  SID1: string;
+
+  @IsString()
+  SID2: string;
+
+  @IsString()
+  SID3: string;
+
+  @IsString()
+  SID4: string;
+
+  @IsString()
+  SID5: string;
+
+  @IsString()
+  SID6: string;
+
+  @IsString()
+  SID7: string;
+
+  @IsString()
+  SID8: string;
+
+  @IsString()
+  SID9: string;
+
+  @IsString()
+  SID10: string;
+
+  @IsString()
+  NumberOfElement: string;
+}
+
+export class ElementDataDto {
+  @IsString()
+  ElementName: string;
+
+  @IsString()
+  ElementFlag: string;
+
+  @IsString()
+  LowerGrade: string;
+
+  @IsString()
+  UpperGrade: string;
+
+  @IsString()
+  InternalLowerGrade: string;
+
+  @IsString()
+  InternalUpperGrade: string;
+
+  @IsString()
+  ElementValue: string;
+}
+
+export class CreateQclabDto {
+  @ValidateNested()
+  @Type(() => HeaderDataDto)
+  headerData: HeaderDataDto;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ElementDataDto)
+  elementData: ElementDataDto[];
+}

--- a/src/qclab/qclab-element.entity.ts
+++ b/src/qclab/qclab-element.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Qclab } from './qclab.entity';
+
+@Entity()
+export class QclabElement {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Qclab, (qclab) => qclab.elements, { onDelete: 'CASCADE' })
+  qclab: Qclab;
+
+  @Column()
+  ElementName: string;
+
+  @Column()
+  ElementFlag: string;
+
+  @Column()
+  LowerGrade: string;
+
+  @Column()
+  UpperGrade: string;
+
+  @Column()
+  InternalLowerGrade: string;
+
+  @Column()
+  InternalUpperGrade: string;
+
+  @Column()
+  ElementValue: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/qclab/qclab.controller.ts
+++ b/src/qclab/qclab.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { QclabService } from './qclab.service';
+import { CreateQclabDto } from './dto/create-qclab.dto';
+
+@Controller('qclab')
+export class QclabController {
+  constructor(private readonly qclabService: QclabService) {}
+
+  @Post()
+  create(@Body() createQclabDto: CreateQclabDto) {
+    return this.qclabService.create(createQclabDto);
+  }
+}

--- a/src/qclab/qclab.entity.ts
+++ b/src/qclab/qclab.entity.ts
@@ -1,0 +1,108 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { QclabElement } from './qclab-element.entity';
+
+@Entity()
+export class Qclab {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  CompanyCode: string;
+
+  @Column()
+  BranchCode: string;
+
+  @Column()
+  UnitCode: string;
+
+  @Column()
+  DataSource: string;
+
+  @Column()
+  AnalysisType: string;
+
+  @Column()
+  Time: string;
+
+  @Column()
+  Day: string;
+
+  @Column()
+  Month: string;
+
+  @Column()
+  Year: string;
+
+  @Column()
+  AnalyticalMethod: string;
+
+  @Column()
+  AnalyticalTask: string;
+
+  @Column()
+  Grade: string;
+
+  @Column()
+  TypeStandard: string;
+
+  @Column()
+  RunsDone: string;
+
+  @Column()
+  RunsInAverage: string;
+
+  @Column()
+  RunNumber: string;
+
+  @Column()
+  RunType: string;
+
+  @Column()
+  SID1: string;
+
+  @Column()
+  SID2: string;
+
+  @Column()
+  SID3: string;
+
+  @Column()
+  SID4: string;
+
+  @Column()
+  SID5: string;
+
+  @Column()
+  SID6: string;
+
+  @Column()
+  SID7: string;
+
+  @Column()
+  SID8: string;
+
+  @Column()
+  SID9: string;
+
+  @Column()
+  SID10: string;
+
+  @Column()
+  NumberOfElement: string;
+
+  @OneToMany(() => QclabElement, (element) => element.qclab, { cascade: true })
+  elements: QclabElement[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/qclab/qclab.module.ts
+++ b/src/qclab/qclab.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { QclabController } from './qclab.controller';
+import { QclabService } from './qclab.service';
+import { Qclab } from './qclab.entity';
+import { QclabElement } from './qclab-element.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Qclab, QclabElement])],
+  controllers: [QclabController],
+  providers: [QclabService],
+})
+export class QclabModule {}

--- a/src/qclab/qclab.service.ts
+++ b/src/qclab/qclab.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateQclabDto } from './dto/create-qclab.dto';
+import { Qclab } from './qclab.entity';
+
+@Injectable()
+export class QclabService {
+  constructor(
+    @InjectRepository(Qclab)
+    private readonly qclabRepository: Repository<Qclab>,
+  ) {}
+
+  async create(createQclabDto: CreateQclabDto) {
+    const qclab = this.qclabRepository.create({
+      ...createQclabDto.headerData,
+      elements: createQclabDto.elementData,
+    });
+    return this.qclabRepository.save(qclab);
+  }
+}


### PR DESCRIPTION
## Summary
- add qclab module with controller, service, and DTOs
- register qclab module in application module
- persist qclab requests with TypeORM entities and migration

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unsafe member access .save on an `error` typed value)*

------
https://chatgpt.com/codex/tasks/task_e_68b12c7e2bc483319f5758ad055d59a4